### PR TITLE
Updated Corretto Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY --chown=gradle:gradle . /home/gradle/src
 WORKDIR /home/gradle/src
 RUN gradle buildFatJar --no-daemon
 
-FROM amazoncorretto:22 AS runtime
+FROM amazoncorretto:23-alpine AS runtime
 EXPOSE 8080
 RUN mkdir /app
 COPY --from=build /home/gradle/src/build/libs/*.jar /app/linkoraSyncServer.jar


### PR DESCRIPTION
I used a newer Amazon Corretto image because the current one has vulnerabilities, and I opted for an Alpine-based image, which results in a smaller Docker image file (approximately 600~ MB compared to 800+ MB). 

![image](https://github.com/user-attachments/assets/383afc27-4937-4cde-8c51-0822debe3c6f)
![image](https://github.com/user-attachments/assets/5f949522-48d8-4de8-9bec-2d6f0c8060b8)

I have tested a similiar build of the image with a custom Docker image that I personally use (which includes pre-installed SQLite binaries)
 